### PR TITLE
Generate footnote IDs and move footnote defs out of the tree

### DIFF
--- a/src/Node.zig
+++ b/src/Node.zig
@@ -108,8 +108,17 @@ pub fn listIsTight(n: Node) bool {
     return 1 == c.cmark_node_get_list_tight(n.n);
 }
 
+pub fn parentFootnoteDef(n: Node) ?Node {
+    const ptr = c.cmark_node_parent_footnote_def(n.n) orelse return null;
+    return .{ .n = ptr };
+}
+
 pub fn footnoteDefCount(n: Node) i32 {
     return c.cmark_node_get_footnote_def_count(n.n);
+}
+
+pub fn footnoteRefIx(n: Node) i32 {
+    return c.cmark_node_get_footnote_ref_ix(n.n);
 }
 
 pub fn parent(n: Node) ?Node {


### PR DESCRIPTION
This basically follows your implementation plan in kristoff-it/zine#92. Conveniently, `cmark-gfm`'s [`process_footnotes`](https://github.com/kristoff-it/cmark-gfm/blob/6e7c42a2a4bb28f3adcae425c5e141f561b6eb43/src/blocks.c#L465-L542) function already does the following before giving us an AST:
- converts unmatched footnote references to text nodes
- sorts footnote definitions by the order in which they are first referenced.
- removes footnote definitions that are not referenced
- moves footnote definitions to the end of the document

So basically all I had to do was generate IDs, store them, and move footnote definitions out of the document tree.