### PR TITLE
Stop outputting `alt=""` on commonmark style images

### DIFF
--- a/src/Node.zig
+++ b/src/Node.zig
@@ -82,7 +82,12 @@ pub fn link(self: Node) ?[:0]const u8 {
 }
 pub fn title(self: Node) ?[:0]const u8 {
     const ptr = c.cmark_node_get_title(self.n) orelse return null;
-    return std.mem.span(ptr);
+    const str = std.mem.span(ptr);
+    if (str.len == 0) {
+        return null;
+    } else {
+        return str;
+    }
 }
 pub fn literal(self: Node) ?[:0]const u8 {
     const ptr = c.cmark_node_get_literal(self.n) orelse return null;


### PR DESCRIPTION
Previous output for `![](/image.jpg)`:
`<img src="/image.jpg" alt="" width="400" height="300">`

Output after this patch:
`<img src="/image.jpg" width="400" height="300">`

Commonmark title text is used as the alt text in SuperMD. This is achieved by calling the cmark_node_get_title() function, which has this documentation:

> Returns the title of a link or image node, or an empty string
> if no title is set. Returns NULL if called on a node that is not a link
> or image.

So you can't tell the difference between no title text and empty-string title text using this function. This was resulting in alt="" being applied to the tags of all `![](/image.jpg)` type images.

Having alt="" has special meaning in HTML. From MDN:

> Setting this attribute to an empty string (alt="") indicates that this image is not a key part of the content (it's decoration or a tracking pixel), and that non-visual browsers may omit it from rendering. Visual browsers will also hide the broken image icon if the alt attribute is empty and the image failed to display.

I've fixed this by checking the return value of cmark_node_get_title() for an empty string and replacing it with null if so.
This means you can't set alt="" with `![](/image.jpg "")`, but that is an odd case and we should optimise for the common case. You still can do it with `[]($image.siteAsset('image.jpg').alt(""))` if you really need to.