### PR TITLE
Add ability to include specific code lines

### DIFF
--- a/src/context.zig
+++ b/src/context.zig
@@ -849,6 +849,12 @@ pub const Link = struct {
 pub const Code = struct {
     src: ?Src = null,
     language: ?[]const u8 = null,
+    lines: ?Lines = null,
+
+    pub const Lines = struct {
+        start: usize,
+        end: usize,
+    };
 
     pub const mandatory = .{.src};
     pub const directive_mandatory = .{};
@@ -870,6 +876,7 @@ pub const Code = struct {
             \\Sets the language of this code snippet, which is also used for
             \\syntax highlighting.
         );
+        pub const lines = utils.CodeBuiltins.lines;
     };
 };
 

--- a/src/context/utils.zig
+++ b/src/context/utils.zig
@@ -404,7 +404,7 @@ pub const CodeBuiltins = struct {
         };
         pub const description =
             \\ Limit the included code asset to the specified lines.
-            \\ The end is inclusize.
+            \\ The second argument is inclusive.
             \\
             \\ ```
             \\ []($code.asset("main.zig").lines(10, 15))

--- a/src/context/utils.zig
+++ b/src/context/utils.zig
@@ -396,6 +396,55 @@ pub const SrcBuiltins = struct {
     };
 };
 
+pub const CodeBuiltins = struct {
+    pub const lines = struct {
+        pub const signature: Signature = .{
+            .params = &.{ .int, .int },
+            .ret = .anydirective,
+        };
+        pub const description =
+            \\ Limit the included code asset to the specified lines.
+            \\ The end is inclusize.
+            \\
+            \\ ```
+            \\ []($code.asset("main.zig").lines(10, 15))
+            \\ ```
+            \\ This will include only lines 10 - 15 from the main.zig asset file.
+        ;
+        pub fn call(
+            self: anytype,
+            d: *context.Directive,
+            _: Allocator,
+            _: *const context.Content,
+            args: []const context.Value,
+        ) !context.Value {
+            const bad_arg: context.Value = .{ .err = "expected 2 integer arguments" };
+            if (args.len != 2) return bad_arg;
+
+            const start = switch (args[0]) {
+                .int => |i| i,
+                else => return bad_arg,
+            };
+
+            const end = switch (args[0]) {
+                .int => |i| i,
+                else => return bad_arg,
+            };
+            const neg_arg: context.Value = .{ .err = "arg must be not negative" };
+            if (start < 0 or end < 0) return neg_arg;
+
+            if (self.lines != null) {
+                return .{ .err = "field already set" };
+            }
+            @field(self, "lines") = .{
+                .start = @intCast(start),
+                .end = @intCast(start),
+            };
+            return .{ .directive = d };
+        }
+    };
+};
+
 //NOTE: this must be kept in sync with SuperHTML
 pub fn pathValidationError(path: []const u8) ?context.Value {
     // Paths must not have spaces around them

--- a/src/context/utils.zig
+++ b/src/context/utils.zig
@@ -426,7 +426,7 @@ pub const CodeBuiltins = struct {
                 else => return bad_arg,
             };
 
-            const end = switch (args[0]) {
+            const end = switch (args[1]) {
                 .int => |i| i,
                 else => return bad_arg,
             };
@@ -438,7 +438,7 @@ pub const CodeBuiltins = struct {
             }
             @field(self, "lines") = .{
                 .start = @intCast(start),
-                .end = @intCast(start),
+                .end = @intCast(end),
             };
             return .{ .directive = d };
         }


### PR DESCRIPTION
As proposed in #12 , this adds the ability to specify the lines of a Code asset that you want to include.
I'll work to make the necessary changes to Zine as well.