### PR TITLE
feat: add support for audio embeds

### DIFF
--- a/src/context.zig
+++ b/src/context.zig
@@ -789,7 +789,7 @@ pub const Audio = struct {
     loop: ?bool = null,
     muted: ?bool = null,
     autoplay: ?bool = null,
-    controls: ?bool = null,
+    hide_controls: ?bool = null,
 
     pub const mandatory = .{.src};
     pub const directive_mandatory = .{};
@@ -815,8 +815,8 @@ pub const Audio = struct {
         pub const autoplay = utils.directiveBuiltin("autoplay", .bool,
             \\If true, the audio file will start playing automatically.
         );
-        pub const controls = utils.directiveBuiltin("controls", .bool,
-            \\If true, the audio file will display controls (e.g. play/pause,
+        pub const hide_controls = utils.directiveBuiltin("hide_controls", .bool,
+            \\If true, the audio file will hide its controls (e.g. play/pause,
             \\volume).
         );
 

--- a/src/context.zig
+++ b/src/context.zig
@@ -16,6 +16,7 @@ pub const Content = struct {
     code: Directive = .{ .kind = .{ .code = .{} } },
     image: Directive = .{ .kind = .{ .image = .{} } },
     video: Directive = .{ .kind = .{ .video = .{} } },
+    audio: Directive = .{ .kind = .{ .audio = .{} } },
 
     pub const dot = scripty.defaultDot(Content, Value, true);
     pub const description =
@@ -34,6 +35,7 @@ pub const Content = struct {
         pub const code = Code.description;
         pub const image = Image.description;
         pub const video = Video.description;
+        pub const audio = Audio.description;
     };
     pub const Builtins = struct {};
 };
@@ -130,6 +132,7 @@ pub const Directive = struct {
         heading: Heading,
         image: Image,
         video: Video,
+        audio: Audio,
         link: Link,
         code: Code,
         text: Text,
@@ -283,10 +286,10 @@ pub const Directive = struct {
             pub const description =
                 \\Adds data key-value pairs of a Directive.
                 \\
-                \\In SuperHTML data key-value pairs can be accessed 
+                \\In SuperHTML data key-value pairs can be accessed
                 \\programmatically in a template when rendering
                 \\a section, while data will turn into `data-foo`
-                \\attributes otherwise. 
+                \\attributes otherwise.
             ;
 
             pub fn call(
@@ -343,7 +346,7 @@ pub const Section = struct {
 
     pub const description =
         \\A content section, used to define a portion of content
-        \\that can be rendered individually by a template. 
+        \\that can be rendered individually by a template.
     ;
 
     pub fn validate(gpa: Allocator, d: *Directive, ctx: Node) !?Value {
@@ -448,7 +451,7 @@ pub const Mathtex = struct {
         \\collisions with other SuperMD syntax.
         \\
         \\This JS based solution is temporary. Zine will eventually implement
-        \\its own way of outputting MathML at buildtime so that clients won't 
+        \\its own way of outputting MathML at buildtime so that clients won't
         \\need to have JS enabled.
         \\
         \\To render math formulas as separate blocks, use this syntax:
@@ -459,7 +462,7 @@ pub const Mathtex = struct {
         \\
         \\Example:
         \\```markdown
-        \\Here's some [`x+\sqrt{1-x^2}`]($mathtex) math. 
+        \\Here's some [`x+\sqrt{1-x^2}`]($mathtex) math.
         \\```
         \\
         \\This will be rendered by SuperHTML as:
@@ -532,10 +535,10 @@ pub const Block = struct {
     };
 
     pub const description =
-        \\When placed at the beginning of a Markdown quote block, the quote 
+        \\When placed at the beginning of a Markdown quote block, the quote
         \\block becomes a styleable container for elements.
         \\
-        \\SuperHTML will automatically give the class `block` when rendering 
+        \\SuperHTML will automatically give the class `block` when rendering
         \\Block directives.
         \\
         \\Example:
@@ -549,7 +552,7 @@ pub const Block = struct {
         \\>This is now a block.
         \\>Lorem ipsum.
         \\
-        \\Differently from Sections, Blocks cannot be rendered independently 
+        \\Differently from Sections, Blocks cannot be rendered independently
         \\and can be nested.
         \\
         \\Example:
@@ -572,8 +575,8 @@ pub const Block = struct {
         \\>
         \\>back to the outer block
         \\
-        \\A block can optionally wrap a Markdown heading element. In this case  
-        \\the generated Block will be rendered with two separate sub-containers: 
+        \\A block can optionally wrap a Markdown heading element. In this case
+        \\the generated Block will be rendered with two separate sub-containers:
         \\one for the block title and one for the body.
         \\
         \\Example:
@@ -757,21 +760,64 @@ pub const Video = struct {
     ;
     pub const Builtins = struct {
         pub const loop = utils.directiveBuiltin("loop", .bool,
-            \\If true, the video will seek back to the start upon reaching the 
+            \\If true, the video will seek back to the start upon reaching the
             \\end.
         );
         pub const muted = utils.directiveBuiltin("muted", .bool,
-            \\If true, the video will be silenced at start. 
+            \\If true, the video will be silenced at start.
         );
         pub const autoplay = utils.directiveBuiltin("autoplay", .bool,
-            \\If true, the video will start playing automatically. 
+            \\If true, the video will start playing automatically.
         );
         pub const controls = utils.directiveBuiltin("controls", .bool,
-            \\If true, the video will display controls (e.g. play/pause, volume). 
+            \\If true, the video will display controls (e.g. play/pause, volume).
         );
         pub const pip = utils.directiveBuiltin("pip", .bool,
-            \\If **false**, clients shouldn't try to display the video in a 
+            \\If **false**, clients shouldn't try to display the video in a
             \\Picture-in-Picture context.
+        );
+
+        pub const url = utils.SrcBuiltins.url;
+        pub const asset = utils.SrcBuiltins.asset;
+        pub const siteAsset = utils.SrcBuiltins.siteAsset;
+        pub const buildAsset = utils.SrcBuiltins.buildAsset;
+    };
+};
+
+pub const Audio = struct {
+    src: ?Src = null,
+    loop: ?bool = null,
+    muted: ?bool = null,
+    autoplay: ?bool = null,
+    controls: ?bool = null,
+
+    pub const mandatory = .{.src};
+    pub const directive_mandatory = .{};
+    pub const description =
+        \\An embedded audio file.
+        \\
+        \\Any text placed between `[]` will be used as a caption for the audio
+        \\file.
+        \\
+        \\Example:
+        \\```markdown
+        \\[This is the caption]($audio.asset('foo.wav'))
+        \\```
+    ;
+    pub const Builtins = struct {
+        pub const loop = utils.directiveBuiltin("loop", .bool,
+            \\If true, the audio file will seek back to the start upon reaching
+            \\the end.
+        );
+        pub const muted = utils.directiveBuiltin("muted", .bool,
+            \\If true, the audio file will be silenced at start.
+        );
+        pub const autoplay = utils.directiveBuiltin("autoplay", .bool,
+            \\If true, the audio file will start playing automatically.
+        );
+        pub const controls = utils.directiveBuiltin("controls", .bool,
+            \\If true, the audio file will display controls (e.g. play/pause,
+            \\volume).
         );
 
         pub const url = utils.SrcBuiltins.url;
@@ -821,7 +867,7 @@ pub const Link = struct {
         pub const sibling = utils.SrcBuiltins.sibling;
         pub const sub = utils.SrcBuiltins.sub;
         pub const new = utils.directiveBuiltin("new", .bool,
-            \\When `true` it asks readers to open the link in a new window or 
+            \\When `true` it asks readers to open the link in a new window or
             \\tab.
         );
         pub const alternative = struct {
@@ -834,7 +880,7 @@ pub const Link = struct {
                 \\alternative version of the page, which can be particularly
                 \\useful when referencing the RSS feed version of a page.
                 \\
-                \\The string argument is the name of an alrenative as defined 
+                \\The string argument is the name of an alrenative as defined
                 \\in the page's `alternatives` frontmatter property.
             ;
 
@@ -872,11 +918,11 @@ pub const Link = struct {
                 \\directive that specifies an `id`) of either the current
                 \\page or a target page set with `page()`.
                 \\
-                \\Zine tracks all ids defined in content files so referencing 
+                \\Zine tracks all ids defined in content files so referencing
                 \\an id that doesn't exist will result in a build error.
                 \\
-                \\Zine does not track ids defined inside of templates so 
-                \\use `unsafeRef` to deep-link to those. 
+                \\Zine does not track ids defined inside of templates so
+                \\use `unsafeRef` to deep-link to those.
             ;
 
             pub fn call(
@@ -912,7 +958,7 @@ pub const Link = struct {
             pub const description =
                 \\Like `ref` but Zine will not perform any id checking.
                 \\
-                \\Can be used to deep-link to ids specified in templates. 
+                \\Can be used to deep-link to ids specified in templates.
             ;
 
             pub fn call(

--- a/src/doctypes.zig
+++ b/src/doctypes.zig
@@ -36,6 +36,7 @@ pub const ScriptyParam = union(enum) {
     Link,
     Image,
     Video,
+    Audio,
     Code,
     str,
     bool,
@@ -59,6 +60,7 @@ pub const ScriptyParam = union(enum) {
             .mathtex => .Mathtex,
             .image => .Image,
             .video => .Video,
+            .audio => .Audio,
             .link => .Link,
             .code => .Code,
         };
@@ -76,6 +78,7 @@ pub const ScriptyParam = union(enum) {
             context.Link => .Link,
             context.Image => .Image,
             context.Video => .Video,
+            context.Audio => .Audio,
             context.Code => .Code,
 
             // context.Template => .any,


### PR DESCRIPTION
Based on the video implementation.

See also: https://github.com/kristoff-it/zine/pull/195

This makes it possible to embed audio assets like this:
`[](<$audio.asset('my-cool-sound.wav').controls(true)>)`

One thing I wasn't sure about was whether to copy the video embed's "no controls" default. I decided to make it show controls by default, because otherwise it wouldn't look like anything happened when you embed a file.

Let me know if you want the controls to be hidden by default, for consistency with video.

*I used no form of AI in the creation of this PR.*